### PR TITLE
Style landing page title with gradient

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -395,7 +395,15 @@ const EskerVendorGuide = () => {
                   {page.icon}
                 </div>
                 <div>
-                  <h2 className="text-3xl font-bold text-gray-900">{page.title}</h2>
+                  <h2
+                    className={`text-3xl font-bold ${
+                      page.id === 'overview'
+                        ? 'bg-gradient-to-r from-indigo-600 via-blue-500 to-cyan-400 bg-clip-text text-transparent drop-shadow-sm'
+                        : 'text-gray-900'
+                    }`}
+                  >
+                    {page.title}
+                  </h2>
                   <p className="text-lg text-gray-600 mt-1">{page.subtitle}</p>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- add a gradient text treatment to the landing page heading so it matches the styling used in the Python app

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e46c1fe404832ca8237ed438b75118